### PR TITLE
adding reusable workflow for PR review notifications.

### DIFF
--- a/.github/workflows/pull_request_review_requested.json
+++ b/.github/workflows/pull_request_review_requested.json
@@ -1,0 +1,9 @@
+{
+  "pull_request": {
+    "html_url": "https://github.com/vector-remote-care/github-actions/pull/1"
+  },
+  "requested_reviewer": {
+    "type": "Team",
+    "login": "da"
+  }
+}

--- a/.github/workflows/ringcentral-reviewer-notify.yml
+++ b/.github/workflows/ringcentral-reviewer-notify.yml
@@ -1,0 +1,30 @@
+name: Notify RingCentral When Reviewer Added
+on:
+  workflow_call:
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Map team to webhook
+        id: map
+        run: |
+          if [[ "${{ github.event.requested_reviewer.type }}" != "Team" ]]; then
+            echo "notify=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          TEAM="${{ github.event.requested_reviewer.login }}"
+          if [[ "$TEAM" == "da" ]]; then
+            echo "webhook=https://hooks.ringcentral.com/webhook/v2/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvdCI6ImMiLCJvaSI6IjExNjUzODU3MjkiLCJpZCI6IjIzMjYzNjQxODcifQ.-CUqmsraBYvjn1Bgq4TElNfunV1aYY2--Mf_ETmrF1s" >> $GITHUB_OUTPUT
+            echo "notify=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+      - name: Send notification to RingCentral
+        if: steps.map.outputs.notify == 'true'
+        run: |
+          curl -X POST -H 'Content-Type: application/json' \
+            -d '{
+                "iconUri": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                "text": "**PR ready for review**: ${{ github.event.pull_request.html_url }}\nRemember to use helpful emojis to let the team know if you approve or have questions!\n👀 Currently reviewing\n✅ Approved\n❓ Questions? Reply with comments here"
+            }' \
+            "${{ steps.map.outputs.webhook }}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# GitHub Actions Shared Workflows Repository
+
+This repository is designed to host shared and reusable GitHub Actions workflows for the organization. By centralizing common automation logic here, you can:
+
+- Reduce duplication across repositories
+- Standardize CI/CD and notification processes
+- Easily maintain and update workflows in one place
+
+Workflows in this repo can be referenced from any other repository in the organization using the `workflow_call` feature, making it simple to share automation logic.
+
+---
+
+## RingCentral PR Review Notification Workflow
+
+One example workflow in this repository sends notifications to RingCentral when a review is requested from specific GitHub teams on a pull request.
+
+### Features
+
+- Supports multiple teams, each mapped to a different RingCentral webhook
+- Sends a formatted message to the appropriate RingCentral channel when a team is requested for review
+- Easily reusable in other repositories via `workflow_call`
+
+---
+
+### How to Use in Other Repositories
+
+1. Reference the workflow in your repo's `.github/workflows/` directory:
+   ```yaml
+   name: RingCentral PR Review Notification
+   on:
+     pull_request:
+       types: [review_requested]
+   jobs:
+     notify:
+       uses: vector-remote-care/github-actions/.github/workflows/ringcentral-reviewer-notify.yml@main
+   ```
+2. Make sure your teams and webhook URLs are configured in the shared workflow.
+
+---
+
+### Local Testing with act
+
+You can test the workflow locally using [act](https://github.com/nektos/act):
+
+1. Create a test event file, e.g. `.github/workflows/pull_request_review_requested.json`:
+   ```json
+   {
+     "pull_request": {
+       "html_url": "https://github.com/vector-remote-care/github-actions/pull/1"
+     },
+     "requested_reviewer": {
+       "type": "Team",
+       "login": "da"
+     }
+   }
+   ```
+2. Run the workflow locally:
+   ```sh
+   act -e .github/workflows/pull_request_review_requested.json -j notify
+   ```
+
+---
+
+### Customization
+
+- To add more teams or change webhook URLs, edit the mapping logic in `.github/workflows/ringcentral-reviewer-notify.yml`.
+- For questions or improvements, open an issue or pull request.


### PR DESCRIPTION
## PR: Add Reusable RingCentral PR Review Notification Workflow

### Summary
This PR introduces a reusable GitHub Actions workflow that sends formatted notifications to RingCentral when a review is requested from specific GitHub teams on a pull request.

### Key Features
- Supports multiple teams, each mapped to a different RingCentral webhook.
  - currently only a single team is configured, but more teams can be added by simply adding more if blocks
- Sends a notification to the appropriate RingCentral channel when a team is requested for review.
- Uses the `workflow_call` trigger for easy reuse across repositories.
- Includes clear documentation and local testing instructions in the README.

### Usage
- Reference this workflow from any repo using the `uses:` keyword and `workflow_call`.
- Add or update team-to-webhook mappings in the workflow file as needed.

### Testing
- Local testing supported via [act](https://github.com/nektos/act) with provided event payload examples.

### Customization
- To add more teams or change webhook URLs, update the mapping logic in ringcentral-reviewer-notify.yml.
